### PR TITLE
added build dir and sysimport of the builded module

### DIFF
--- a/torch_utils/custom_ops.py
+++ b/torch_utils/custom_ops.py
@@ -57,6 +57,7 @@ def _get_mangled_gpu_name():
 _cached_plugins = dict()
 
 def get_plugin(module_name, sources, headers=None, source_dir=None, **build_kwargs):
+    import sys  # <-- added
     assert verbosity in ['none', 'brief', 'full']
     if headers is None:
         headers = []
@@ -64,60 +65,39 @@ def get_plugin(module_name, sources, headers=None, source_dir=None, **build_kwar
         sources = [os.path.join(source_dir, fname) for fname in sources]
         headers = [os.path.join(source_dir, fname) for fname in headers]
 
-    # Already cached?
     if module_name in _cached_plugins:
         return _cached_plugins[module_name]
 
-    # Print status.
     if verbosity == 'full':
         print(f'Setting up PyTorch plugin "{module_name}"...')
     elif verbosity == 'brief':
         print(f'Setting up PyTorch plugin "{module_name}"... ', end='', flush=True)
     verbose_build = (verbosity == 'full')
 
-    # Compile and load.
-    try: # pylint: disable=too-many-nested-blocks
-        # Make sure we can find the necessary compiler binaries.
+    build_dir = None  # <-- added: will point to folder containing the built .so
+
+    try:
         if os.name == 'nt' and os.system("where cl.exe >nul 2>nul") != 0:
             compiler_bindir = _find_compiler_bindir()
             if compiler_bindir is None:
                 raise RuntimeError(f'Could not find MSVC/GCC/CLANG installation on this computer. Check _find_compiler_bindir() in "{__file__}".')
             os.environ['PATH'] += ';' + compiler_bindir
 
-        # Some containers set TORCH_CUDA_ARCH_LIST to a list that can either
-        # break the build or unnecessarily restrict what's available to nvcc.
-        # Unset it to let nvcc decide based on what's available on the
-        # machine.
         os.environ['TORCH_CUDA_ARCH_LIST'] = ''
 
-        # Incremental build md5sum trickery.  Copies all the input source files
-        # into a cached build directory under a combined md5 digest of the input
-        # source files.  Copying is done only if the combined digest has changed.
-        # This keeps input file timestamps and filenames the same as in previous
-        # extension builds, allowing for fast incremental rebuilds.
-        #
-        # This optimization is done only in case all the source files reside in
-        # a single directory (just for simplicity) and if the TORCH_EXTENSIONS_DIR
-        # environment variable is set (we take this as a signal that the user
-        # actually cares about this.)
-        #
-        # EDIT: We now do it regardless of TORCH_EXTENSIOS_DIR, in order to work
-        # around the *.cu dependency bug in ninja config.
-        #
         all_source_files = sorted(sources + headers)
         all_source_dirs = set(os.path.dirname(fname) for fname in all_source_files)
-        if len(all_source_dirs) == 1: # and ('TORCH_EXTENSIONS_DIR' in os.environ):
 
-            # Compute combined hash digest for all source files.
+        if len(all_source_dirs) == 1:
             hash_md5 = hashlib.md5()
             for src in all_source_files:
                 with open(src, 'rb') as f:
                     hash_md5.update(f.read())
 
-            # Select cached build directory name.
             source_digest = hash_md5.hexdigest()
-            build_top_dir = torch.utils.cpp_extension._get_build_directory(module_name, verbose=verbose_build) # pylint: disable=protected-access
+            build_top_dir = torch.utils.cpp_extension._get_build_directory(module_name, verbose=verbose_build)  # pylint: disable=protected-access
             cached_build_dir = os.path.join(build_top_dir, f'{source_digest}-{_get_mangled_gpu_name()}')
+            build_dir = cached_build_dir  # <-- added
 
             if not os.path.isdir(cached_build_dir):
                 tmpdir = f'{build_top_dir}/srctmp-{uuid.uuid4().hex}'
@@ -125,20 +105,34 @@ def get_plugin(module_name, sources, headers=None, source_dir=None, **build_kwar
                 for src in all_source_files:
                     shutil.copyfile(src, os.path.join(tmpdir, os.path.basename(src)))
                 try:
-                    os.replace(tmpdir, cached_build_dir) # atomic
+                    os.replace(tmpdir, cached_build_dir)
                 except OSError:
-                    # source directory already exists, delete tmpdir and its contents.
                     shutil.rmtree(tmpdir)
-                    if not os.path.isdir(cached_build_dir): raise
+                    if not os.path.isdir(cached_build_dir):
+                        raise
 
-            # Compile.
             cached_sources = [os.path.join(cached_build_dir, os.path.basename(fname)) for fname in sources]
-            torch.utils.cpp_extension.load(name=module_name, build_directory=cached_build_dir,
-                verbose=verbose_build, sources=cached_sources, **build_kwargs)
+            torch.utils.cpp_extension.load(
+                name=module_name,
+                build_directory=cached_build_dir,
+                verbose=verbose_build,
+                sources=cached_sources,
+                **build_kwargs,
+            )
         else:
-            torch.utils.cpp_extension.load(name=module_name, verbose=verbose_build, sources=sources, **build_kwargs)
+            # Torch will pick its default build directory; try to infer it.
+            build_dir = torch.utils.cpp_extension._get_build_directory(module_name, verbose=verbose_build)  # pylint: disable=protected-access
+            torch.utils.cpp_extension.load(
+                name=module_name,
+                verbose=verbose_build,
+                sources=sources,
+                **build_kwargs,
+            )
 
-        # Load.
+        # ---- FIX: ensure the directory containing *.so is importable ----
+        if build_dir and os.path.isdir(build_dir) and build_dir not in sys.path:
+            sys.path.insert(0, build_dir)
+
         module = importlib.import_module(module_name)
 
     except:
@@ -146,12 +140,10 @@ def get_plugin(module_name, sources, headers=None, source_dir=None, **build_kwar
             print('Failed!')
         raise
 
-    # Print status and add to cache dict.
     if verbosity == 'full':
         print(f'Done setting up PyTorch plugin "{module_name}".')
     elif verbosity == 'brief':
         print('Done.')
+
     _cached_plugins[module_name] = module
     return module
-
-#----------------------------------------------------------------------------


### PR DESCRIPTION
### Why

The PyTorch C++/CUDA extension (`upfirdn2d_plugin`) was compiled successfully, but runtime failed with `ModuleNotFoundError` because Python could not locate the generated `.so` file.

---

### What

Ensure that the directory containing the compiled extension is added to Python’s import path before attempting to import the module.

---

### How

* Track the actual build directory used by `torch.utils.cpp_extension.load()` (hashed cache directory).
* Explicitly prepend this directory to `sys.path`.
* Import the extension via `importlib.import_module()` once the path is visible.

```python
import sys
sys.path.insert(0, build_dir)
module = importlib.import_module(module_name)
```

This change affects only Python import resolution; CUDA flags, compiler settings, and build logic remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures compiled PyTorch C++/CUDA extensions are importable after build.
> 
> - Capture the actual build directory (`build_dir`) for both cached and default builds
> - Prepend `build_dir` to `sys.path` before `importlib.import_module(module_name)`
> - Minor refactor/formatting in `get_plugin` without changing build flags or logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cfa95691d55c226c0a3f9f5cbe4597740dec5ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->