### PR TITLE
4 timed out waiting 600000ms for send operation to complete

### DIFF
--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -33,9 +33,9 @@ from metrics import metric_main
 def setup_snapshot_image_grid(training_set, random_seed=0, gw=None, gh=None):
     rnd = np.random.RandomState(random_seed)
     if gw is None:
-        gw = np.clip(7680 // training_set.image_shape[2], 7, 32)
+        gw = max(np.clip(2560 // training_set.image_shape[2], 7, 32), 1)
     if gh is None:
-        gh = np.clip(4320 // training_set.image_shape[1], 4, 32)
+        gh = max(np.clip(1440 // training_set.image_shape[1], 4, 32), 1)
 
     # No labels => show random subset of training samples.
     if not training_set.has_labels:


### PR DESCRIPTION
1) Added generate_snapshot_grid_images() that:
Slices the grid across ranks (round-robin by index), so each GPU generates ~1/num_gpus of images.

Runs inference in batch_gpu microbatches per rank.

Uses torch.distributed.all_gather() to collect per-rank outputs, then rank 0 reorders and trims to the original N and saves the PNG.

2) Replaced the two original torch.cat([G_ema(...)...]).numpy() blocks with calls to this helper.
3) Reduced snapshot grid size by 3× per dimension in setup_snapshot_image_grid() (effectively ~9× fewer images), making snapshot PNGs and generation faster.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Speeds up and stabilizes image snapshots and logging during training.
> 
> - Adds `generate_snapshot_grid_images` to shard snapshot generation across GPUs with microbatches and `all_gather`, returning ordered results; used for `fakes_init.png` and periodic `fakes*.png` snapshots
> - Shrinks snapshot grid (approx 3× smaller per dimension: `gw 7680→2560`, `gh 4320→1440`, clamped to ≥1) to reduce work and PNG size
> - Introduces timed `stage()` logging and replaces scattered prints across setup, snapshotting, checkpoints, metrics, and exit
> - Uses deterministic seeding for `grid_z` and adjusts multi-GPU flow so only rank 0 saves images/files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a9941b6b8ae771c82756c29eff8106d2f0b7eeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->