### PR TITLE
4 timed out waiting 600000ms for send operation to complete

### DIFF
--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -33,9 +33,9 @@ from metrics import metric_main
 def setup_snapshot_image_grid(training_set, random_seed=0, gw=None, gh=None):
     rnd = np.random.RandomState(random_seed)
     if gw is None:
-        gw = np.clip(7680 // training_set.image_shape[2], 7, 32)
+        gw = max(np.clip(2560 // training_set.image_shape[2], 7, 32), 1)
     if gh is None:
-        gh = np.clip(4320 // training_set.image_shape[1], 4, 32)
+        gh = max(np.clip(1440 // training_set.image_shape[1], 4, 32), 1)
 
     # No labels => show random subset of training samples.
     if not training_set.has_labels:


### PR DESCRIPTION
1) Added generate_snapshot_grid_images() that:
Slices the grid across ranks (round-robin by index), so each GPU generates ~1/num_gpus of images.

Runs inference in batch_gpu microbatches per rank.

Uses torch.distributed.all_gather() to collect per-rank outputs, then rank 0 reorders and trims to the original N and saves the PNG.

2) Replaced the two original torch.cat([G_ema(...)...]).numpy() blocks with calls to this helper.
3) Reduced snapshot grid size by 3× per dimension in setup_snapshot_image_grid() (effectively ~9× fewer images), making snapshot PNGs and generation faster.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes snapshot image generation and improves training logs.
> 
> - Adds `generate_snapshot_grid_images()` to shard `grid_z/grid_c` across GPUs, microbatch per-rank, `all_gather` outputs, and assemble on rank 0
> - Replaces both `torch.cat([G_ema(...)...]).numpy()` sites with the new helper; seeds `grid_z` with a per-run deterministic generator
> - Reduces snapshot grid size in `setup_snapshot_image_grid()` (from 7680×4320-based to 2560×1440-based heuristics) to generate ~9× fewer images
> - Introduces `stage()` logger and converts major prints (loading, constructing, augmentation, distribution, phases, exporting, training start, snapshots, checkpoints, metrics, exit) to stage-based messages
> - Adjusts image snapshot path to work in multi-GPU: all ranks generate their shard; rank 0 saves PNG
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a9941b6b8ae771c82756c29eff8106d2f0b7eeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->