### PR TITLE
Remove excessive synchronization that caused 65x slowdown on H200

### DIFF
--- a/torch_utils/ops/bias_act.py
+++ b/torch_utils/ops/bias_act.py
@@ -82,8 +82,6 @@ def bias_act(x, b=None, dim=1, act='linear', alpha=None, gain=None, clamp=None, 
     assert isinstance(x, torch.Tensor)
     assert impl in ['ref', 'cuda']
     if impl == 'cuda' and x.device.type == 'cuda' and _init():
-        # Ensure input is contiguous for optimal CUDA kernel performance
-        x = x.contiguous()
         return _bias_act_cuda(dim=dim, act=act, alpha=alpha, gain=gain, clamp=clamp).apply(x, b)
     return _bias_act_ref(x=x, b=b, dim=dim, act=act, alpha=alpha, gain=gain, clamp=clamp)
 

--- a/torch_utils/ops/filtered_lrelu.py
+++ b/torch_utils/ops/filtered_lrelu.py
@@ -213,12 +213,6 @@ def _filtered_lrelu_cuda(up=1, down=1, padding=0, gain=np.sqrt(2), slope=0.2, cl
 
             # Call C++/Cuda plugin if datatype is supported.
             if x.dtype in [torch.float16, torch.float32, torch.bfloat16]:
-                # On H200/Hopper and newer GPUs, ensure stream synchronization for correctness
-                current_stream = torch.cuda.current_stream(x.device)
-                default_stream = torch.cuda.default_stream(x.device)
-                if current_stream != default_stream:
-                    # Synchronize to ensure all pending operations complete before kernel launch
-                    current_stream.synchronize()
                 y, so, return_code = _plugin.filtered_lrelu(x, fu, fd, b, si, up, down, px0, px1, py0, py1, sx, sy, gain, slope, clamp, flip_filter, write_signs)
             else:
                 return_code = -1

--- a/torch_utils/ops/upfirdn2d.py
+++ b/torch_utils/ops/upfirdn2d.py
@@ -158,8 +158,6 @@ def upfirdn2d(x, f, up=1, down=1, padding=0, flip_filter=False, gain=1, impl='cu
     assert isinstance(x, torch.Tensor)
     assert impl in ['ref', 'cuda']
     if impl == 'cuda' and x.device.type == 'cuda' and _init():
-        # Ensure input is contiguous for optimal CUDA kernel performance on H200
-        x = x.contiguous()
         return _upfirdn2d_cuda(up=up, down=down, padding=padding, flip_filter=flip_filter, gain=gain).apply(x, f)
     return _upfirdn2d_ref(x, f, up=up, down=down, padding=padding, flip_filter=flip_filter, gain=gain)
 


### PR DESCRIPTION
The previous changes added torch.cuda.synchronize() calls before barriers and all_reduce operations, as well as stream synchronization in filtered_lrelu. These synchronization points serialized GPU operations and prevented proper asynchronous multi-GPU communication, resulting in:
- 0 NVLink traffic during training
- ~3471 sec/kimg instead of ~53 sec/kimg (65x slower)

This commit removes:
- torch.cuda.synchronize() calls in training_loop.py
- current_stream.synchronize() in filtered_lrelu.py
- Redundant .contiguous() calls in bias_act.py and upfirdn2d.py

The NCCL backend and architecture-specific compilation flags are retained as those are correct. The issue was the excessive synchronization overhead.