### PR TITLE
Simplify CUDA compilation - remove experimental flags causing H200 is…

### DIFF
--- a/torch_utils/custom_ops.py
+++ b/torch_utils/custom_ops.py
@@ -24,83 +24,6 @@ from torch.utils.file_baton import FileBaton
 verbosity = 'brief' # Verbosity level: 'none', 'brief', 'full'
 
 #----------------------------------------------------------------------------
-# CUDA architecture detection and flags for Hopper (sm_90) and newer.
-
-def _get_cuda_arch_flags():
-    """Get CUDA architecture flags for compilation, supporting H200/Hopper (sm_90) and beyond."""
-    arch_flags = []
-    
-    # Detect current GPU compute capability
-    if torch.cuda.is_available():
-        device = torch.cuda.current_device()
-        major, minor = torch.cuda.get_device_capability(device)
-        cc = major * 10 + minor
-        
-        # Build gencode flags for detected architecture
-        # Support architectures from Ampere (80) to Hopper (90) and beyond
-        supported_archs = []
-        
-        # Add current GPU architecture
-        if cc >= 70:  # Volta and newer
-            supported_archs.append(cc)
-        
-        # Ensure we have at least Ampere support
-        if 80 not in supported_archs and cc >= 80:
-            supported_archs.append(80)
-            
-        # Add Hopper support for H200 (sm_90)
-        if 90 not in supported_archs and cc >= 90:
-            supported_archs.append(90)
-        
-        # Generate flags for each architecture
-        for arch in sorted(set(supported_archs)):
-            arch_flags.append(f'-gencode=arch=compute_{arch},code=sm_{arch}')
-        
-        # Add PTX for forward compatibility with the highest supported arch
-        if supported_archs:
-            max_arch = max(supported_archs)
-            arch_flags.append(f'-gencode=arch=compute_{max_arch},code=compute_{max_arch}')
-            
-            # For Hopper (sm_90+), add sm_90a variant for enhanced features
-            if max_arch >= 90:
-                arch_flags.append(f'-gencode=arch=compute_90a,code=sm_90a')
-    
-    return arch_flags
-
-def _get_cuda_extra_cflags():
-    """Get extra CUDA compilation flags optimized for modern architectures."""
-    cflags = [
-        '--use_fast_math',
-        '-O3',
-        '--expt-relaxed-constexpr',
-        '-lineinfo',  # Enable line info for profiling/debugging
-        # Note: -fPIC is already added by PyTorch's cpp_extension loader
-    ]
-    
-    # Add architecture-specific optimizations
-    if torch.cuda.is_available():
-        device = torch.cuda.current_device()
-        major, minor = torch.cuda.get_device_capability(device)
-        
-        # Hopper (sm_90) specific optimizations - H100, H200
-        if major >= 9:
-            cflags.extend([
-                '-DHOPPER_ARCH',
-                '--threads', '4',  # Parallel compilation
-                '--maxrregcount=128',  # Optimize register usage for Hopper
-                '-allow-unsupported-compiler',  # Allow newer compilers
-            ])
-        # Ampere (sm_80) optimizations - A100
-        elif major >= 8:
-            cflags.extend([
-                '-DAMPERE_ARCH',
-                '--threads', '4',
-                '--maxrregcount=128',
-            ])
-    
-    return cflags
-
-#----------------------------------------------------------------------------
 # Internal helper funcs.
 
 def _find_compiler_bindir():
@@ -132,30 +55,9 @@ def _get_mangled_gpu_name():
 # Main entry point for compiling and loading C++/CUDA plugins.
 
 _cached_plugins = dict()
-_arch_check_done = False
-
-def _check_arch_compatibility():
-    """Check if compiled kernels are compatible with current GPU architecture.
-    If not, the cache will be invalidated automatically through the hash mechanism.
-    """
-    global _arch_check_done
-    if _arch_check_done:
-        return
-    _arch_check_done = True
-    
-    if torch.cuda.is_available():
-        device = torch.cuda.current_device()
-        major, minor = torch.cuda.get_device_capability(device)
-        gpu_name = torch.cuda.get_device_name(device)
-        print(f'[Custom CUDA Ops] Detected GPU: {gpu_name} (sm_{major}{minor})')
-        if major >= 9:
-            print(f'[Custom CUDA Ops] Using Hopper-optimized compilation settings')
-        elif major >= 8:
-            print(f'[Custom CUDA Ops] Using Ampere-optimized compilation settings')
 
 def get_plugin(module_name, sources, headers=None, source_dir=None, **build_kwargs):
-    import sys  # <-- added
-    _check_arch_compatibility()  # Check GPU architecture on first plugin load
+    import sys
     assert verbosity in ['none', 'brief', 'full']
     if headers is None:
         headers = []
@@ -172,25 +74,7 @@ def get_plugin(module_name, sources, headers=None, source_dir=None, **build_kwar
         print(f'Setting up PyTorch plugin "{module_name}"... ', end='', flush=True)
     verbose_build = (verbosity == 'full')
 
-    build_dir = None  # <-- added: will point to folder containing the built .so
-
-    # Merge user-provided CUDA flags with architecture-specific flags
-    extra_cuda_cflags = build_kwargs.pop('extra_cuda_cflags', [])
-    if isinstance(extra_cuda_cflags, str):
-        extra_cuda_cflags = [extra_cuda_cflags]
-    else:
-        extra_cuda_cflags = list(extra_cuda_cflags)
-    
-    # Add optimized flags for modern CUDA/architectures
-    extra_cuda_cflags.extend(_get_cuda_extra_cflags())
-    
-    # Get architecture flags (gencode for Hopper/H200 support)
-    arch_flags = _get_cuda_arch_flags()
-    if arch_flags:
-        extra_cuda_cflags.extend(arch_flags)
-    
-    # Restore extra_cuda_cflags to build_kwargs
-    build_kwargs['extra_cuda_cflags'] = extra_cuda_cflags
+    build_dir = None
 
     try:
         if os.name == 'nt' and os.system("where cl.exe >nul 2>nul") != 0:
@@ -207,14 +91,11 @@ def get_plugin(module_name, sources, headers=None, source_dir=None, **build_kwar
             for src in all_source_files:
                 with open(src, 'rb') as f:
                     hash_md5.update(f.read())
-            
-            # Include CUDA flags in hash to rebuild when flags change
-            hash_md5.update(str(extra_cuda_cflags).encode())
 
             source_digest = hash_md5.hexdigest()
             build_top_dir = torch.utils.cpp_extension._get_build_directory(module_name, verbose=verbose_build)  # pylint: disable=protected-access
             cached_build_dir = os.path.join(build_top_dir, f'{source_digest}-{_get_mangled_gpu_name()}')
-            build_dir = cached_build_dir  # <-- added
+            build_dir = cached_build_dir
 
             if not os.path.isdir(cached_build_dir):
                 tmpdir = f'{build_top_dir}/srctmp-{uuid.uuid4().hex}'
@@ -237,7 +118,6 @@ def get_plugin(module_name, sources, headers=None, source_dir=None, **build_kwar
                 **build_kwargs,
             )
         else:
-            # Torch will pick its default build directory; try to infer it.
             build_dir = torch.utils.cpp_extension._get_build_directory(module_name, verbose=verbose_build)  # pylint: disable=protected-access
             torch.utils.cpp_extension.load(
                 name=module_name,
@@ -246,7 +126,7 @@ def get_plugin(module_name, sources, headers=None, source_dir=None, **build_kwar
                 **build_kwargs,
             )
 
-        # ---- FIX: ensure the directory containing *.so is importable ----
+        # Ensure the directory containing *.so is importable
         if build_dir and os.path.isdir(build_dir) and build_dir not in sys.path:
             sys.path.insert(0, build_dir)
 

--- a/train.py
+++ b/train.py
@@ -38,20 +38,8 @@ def subprocess_fn(rank, c, temp_dir):
             print(f"Rank {rank} backend = {torch.distributed.get_backend()}", flush=True)
         else:
             init_method = f'file://{init_file}'
-            # Set CUDA device before NCCL init for proper GPU binding on H200
             torch.cuda.set_device(rank)
-            
-            # Configure NCCL for H200/Hopper GPUs
-            os.environ.setdefault('NCCL_DEBUG', 'WARN')
-            os.environ.setdefault('NCCL_IB_DISABLE', '0')  # Enable InfiniBand if available
-            os.environ.setdefault('NCCL_SOCKET_IFNAME', '')  # Let NCCL auto-detect
-            
-            try:
-                torch.distributed.init_process_group(backend='nccl', init_method=init_method, rank=rank, world_size=c.num_gpus)
-                print(f"Rank {rank} initialized with NCCL backend", flush=True)
-            except Exception as e:
-                print(f"Rank {rank} NCCL init failed ({e}), falling back to Gloo", flush=True)
-                torch.distributed.init_process_group(backend='gloo', init_method=init_method, rank=rank, world_size=c.num_gpus)
+            torch.distributed.init_process_group(backend='nccl', init_method=init_method, rank=rank, world_size=c.num_gpus)
             
 
     # Init torch_utils.


### PR DESCRIPTION
…sues

Reverted custom_ops.py to simpler version:
- Removed experimental sm_90a architecture flag
- Removed --maxrregcount=128 and other Hopper-specific flags
- Removed -DHOPPER_ARCH and -DAMPERE_ARCH defines
- Let PyTorch handle architecture detection automatically

Simplified train.py NCCL initialization:
- Removed NCCL environment variable settings
- Kept basic torch.cuda.set_device() and init_process_group()

IMPORTANT: Users should clear the CUDA kernel cache after this change:
  rm -rf ~/.cache/torch_extensions/

This ensures kernels are recompiled without the problematic flags.